### PR TITLE
commented the conditional check in selectEditor so that the external …

### DIFF
--- a/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_widget_id_1041.livecodescript
+++ b/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_widget_id_1041.livecodescript
@@ -44,8 +44,8 @@ on selectEditor
    
    answer file "Select text editor..."
    put it into tEditor
-   if tEditor is not empty then
+   --if tEditor is not empty then
       put tEditor into field "Editor" of this card
       saveUpdatedPrefs
-   end if
+   --end if
 end selectEditor


### PR DESCRIPTION
Found an anomaly here. In trying various external editors for ScriptTracker script editing, I set the external editor to xed. This actually worked for a while and then stopped - I think somewhere along the way I lost the ability to pass arguments to it.

But anyway, I deleted xed from the external editor box and found that the preference stayed at xed - no way to remove that from the setting.
Looking at the selectEditor handler in the script of widget SelectEditor I see you're only saving the preference if the return data from the answer dialog is not empty, so trying to set an empty value will fail. And if there's a value set there then editScriptFile in the ScriptTrackerBehavior script will try to use it.

I commented out the conditional in selectEditor and it seems to work properly. Ideally I suppose the external editor shouldn't be invoked if the AutoExternalEditor checkbox is not selected.