### PR TITLE
modified checkPref to allow an empty external editor pref to delete a…

### DIFF
--- a/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_.livecodescript
+++ b/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_.livecodescript
@@ -17,7 +17,7 @@ end openCard
 
 
 on checkPref pPref, pValue, @xPrefsA, @xPrefsChanged
-   if pValue is empty then exit checkPref
+   --if pValue is empty then exit checkPref
    if pValue is not xPrefsA[pPref] then
       put pValue into xPrefsA[pPref]
       put true into xPrefsChanged


### PR DESCRIPTION
If there is an external editor preference set then ScriptTracker will attempt to use it even if the AutoExternalEditor checkbox is not checked. Clearing an existing editor entry from the text box didn't remove the existing editor, so this patch allows that. It would also be nice if the AutoExternalEditor preference were checked before attempting to launch an external editor, but that's for another day.