### PR TITLE
allow absolute filepaths for the repo

### DIFF
--- a/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1003.livecodescript
+++ b/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1003.livecodescript
@@ -116,6 +116,10 @@ command buildMainStackArray \
    end if
    if char -1 of tBasePath is not "/" then put "/" after tBasePath
    
+   # mdw - allow absolute paths if specified
+   if char 1 of xDataA["ExportPath"] is in "/~" then
+      put empty into tBasePath
+   end if
    // get stack level preferences
    put the customProperties[sPropertySet] of stack pStackName into tProps
    


### PR DESCRIPTION
Didn't want to have the ScriptTracker git repo in my Plugins folder, so I'm enabling fully-qualified file paths in the prefs instead of always having to prefix the current directory.