### PR TITLE
using ~ as a relative path now works

### DIFF
--- a/ScriptTracker.md
+++ b/ScriptTracker.md
@@ -1,95 +1,95 @@
 # ScriptTracker
 **stack "ScriptTracker"**
 * ID: stack "ScriptTracker"
-* [stack_ScriptTracker_](./ScriptTracker_Scripts/stack_ScriptTracker_.livecodescript)
+* [stack_ScriptTracker_](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_.livecodescript)
 
 **card "Tracker" of stack "ScriptTracker"**
 * ID: card id 1002 of stack "ScriptTracker"
-* [stack_ScriptTracker_card_id_1002](./ScriptTracker_Scripts/stack_ScriptTracker_card_id_1002.livecodescript)
+* [stack_ScriptTracker_card_id_1002](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_card_id_1002.livecodescript)
 
 **button "SyncScripts" of card "Tracker" of stack "ScriptTracker"**
 * ID: button id 1004 of card id 1002 of stack "ScriptTracker"
 * Behavior: button id 1003 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1004](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1004.livecodescript)
+* [stack_ScriptTracker_button_id_1004](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1004.livecodescript)
 
 **field "StackName" of card "Tracker" of stack "ScriptTracker"**
 * ID: field id 1007 of card id 1002 of stack "ScriptTracker"
-* [stack_ScriptTracker_field_id_1007](./ScriptTracker_Scripts/stack_ScriptTracker_field_id_1007.livecodescript)
+* [stack_ScriptTracker_field_id_1007](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_field_id_1007.livecodescript)
 
 **button "StackMenu" of card "Tracker" of stack "ScriptTracker"**
 * ID: button id 1008 of card id 1002 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1008](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1008.livecodescript)
+* [stack_ScriptTracker_button_id_1008](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1008.livecodescript)
 
 **button "Automatic" of card "Tracker" of stack "ScriptTracker"**
 * ID: button id 1009 of card id 1002 of stack "ScriptTracker"
 * Behavior: button id 1003 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1009](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1009.livecodescript)
+* [stack_ScriptTracker_button_id_1009](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1009.livecodescript)
 
 **button "Log" of card "Tracker" of stack "ScriptTracker"**
 * ID: button id 1012 of card id 1002 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1012](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1012.livecodescript)
+* [stack_ScriptTracker_button_id_1012](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1012.livecodescript)
 
 **button "Prefs" of card "Tracker" of stack "ScriptTracker"**
 * ID: button id 1014 of card id 1002 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1014](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1014.livecodescript)
+* [stack_ScriptTracker_button_id_1014](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1014.livecodescript)
 
 **widget "SVG Icon" of card "Tracker" of stack "ScriptTracker"**
 * ID: widget id 1017 of card id 1002 of stack "ScriptTracker"
 * Widget Kind: com.livecode.widget.svgpath
-* [stack_ScriptTracker_widget_id_1017](./ScriptTracker_Scripts/stack_ScriptTracker_widget_id_1017.livecodescript)
+* [stack_ScriptTracker_widget_id_1017](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_widget_id_1017.livecodescript)
 
 **widget "Help" of card "Tracker" of stack "ScriptTracker"**
 * ID: widget id 1018 of card id 1002 of stack "ScriptTracker"
 * Widget Kind: com.livecode.widget.svgpath
-* [stack_ScriptTracker_widget_id_1018](./ScriptTracker_Scripts/stack_ScriptTracker_widget_id_1018.livecodescript)
+* [stack_ScriptTracker_widget_id_1018](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_widget_id_1018.livecodescript)
 
 **button "ScriptTrackerBehavior" of card "Behaviors" of stack "ScriptTracker"**
 * ID: button id 1003 of card id 1016 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1003](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1003.livecodescript)
+* [stack_ScriptTracker_button_id_1003](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1003.livecodescript)
 
 **button "P" of card "Behaviors" of stack "ScriptTracker"**
 * ID: button id 1010 of card id 1016 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1010](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1010.livecodescript)
+* [stack_ScriptTracker_button_id_1010](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1010.livecodescript)
 
 **button "T" of card "Behaviors" of stack "ScriptTracker"**
 * ID: button id 1011 of card id 1016 of stack "ScriptTracker"
-* [stack_ScriptTracker_button_id_1011](./ScriptTracker_Scripts/stack_ScriptTracker_button_id_1011.livecodescript)
+* [stack_ScriptTracker_button_id_1011](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1011.livecodescript)
 
 **stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: stack "ScriptTrackerPrefs" of stack "ScriptTracker"
-* [stack_ScriptTrackerPrefs_](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_.livecodescript)
+* [stack_ScriptTrackerPrefs_](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_.livecodescript)
 
 **widget "PrefCardSelector" of bkgnd id 1006 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: widget id 1003 of bkgnd id 1006 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
 * Widget Kind: com.livecode.widget.segmented
-* [stack_ScriptTrackerPrefs_widget_id_1003](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_widget_id_1003.livecodescript)
+* [stack_ScriptTrackerPrefs_widget_id_1003](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_widget_id_1003.livecodescript)
 
 **button "Reinitialize Default Preferences" of card "ScriptTracker" of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: button id 1035 of card id 1034 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
-* [stack_ScriptTrackerPrefs_button_id_1035](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1035.livecodescript)
+* [stack_ScriptTrackerPrefs_button_id_1035](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1035.livecodescript)
 
 **button "SyncBeforeSave" of card "ScriptTracker" of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: button id 1036 of card id 1034 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
-* [stack_ScriptTrackerPrefs_button_id_1036](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1036.livecodescript)
+* [stack_ScriptTrackerPrefs_button_id_1036](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1036.livecodescript)
 
 **button "AutoExternalEditor" of card "ScriptTracker" of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: button id 1037 of card id 1034 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
-* [stack_ScriptTrackerPrefs_button_id_1037](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1037.livecodescript)
+* [stack_ScriptTrackerPrefs_button_id_1037](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1037.livecodescript)
 
 **widget "SelectEditor" of card "ScriptTracker" of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: widget id 1041 of card id 1034 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
 * Widget Kind: com.livecode.widget.svgpath
-* [stack_ScriptTrackerPrefs_widget_id_1041](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_widget_id_1041.livecodescript)
+* [stack_ScriptTrackerPrefs_widget_id_1041](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_widget_id_1041.livecodescript)
 
 **button "Reinitialize Default Preferences" of card "Options" of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: button id 1033 of card id 1002 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
-* [stack_ScriptTrackerPrefs_button_id_1033](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1033.livecodescript)
+* [stack_ScriptTrackerPrefs_button_id_1033](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1033.livecodescript)
 
 **button "Reinitialize Default Preferences" of card "Defaults" of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: button id 1024 of card id 1004 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
-* [stack_ScriptTrackerPrefs_button_id_1024](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1024.livecodescript)
+* [stack_ScriptTrackerPrefs_button_id_1024](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1024.livecodescript)
 
 **button "Reinitialize Stack Defaults" of card "Stack" of stack "ScriptTrackerPrefs" of stack "ScriptTracker"**
 * ID: button id 1015 of card id 1005 of stack "ScriptTrackerPrefs" of stack "ScriptTracker"
-* [stack_ScriptTrackerPrefs_button_id_1015](./ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1015.livecodescript)
+* [stack_ScriptTrackerPrefs_button_id_1015](.//home/mwieder/scriptTracker/ScriptTracker_Scripts/stack_ScriptTrackerPrefs_button_id_1015.livecodescript)
 

--- a/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1003.livecodescript
+++ b/ScriptTracker_Scripts/stack_ScriptTracker_button_id_1003.livecodescript
@@ -169,7 +169,11 @@ command ensureDirectoryExists \
       put pMergePath into xRelativePath
    end if
    if _pathIsRelative(xRelativePath) then
-      put pBasePath & xRelativePath into tFullPath
+      if char 1 of xRelativePath is "~" then
+         put specialFolderPath("home") & xRelativePath into tFullPath
+      else
+         put pBasePath & xRelativePath into tFullPath
+      end if
    else
       put xRelativePath into tFullPath
    end if


### PR DESCRIPTION
This patch uses specialFolderpath("home") as a replacement for "~" when a path relative to the user's home directory is specified. Without this patch the base path is prepended to "~" and the rest of the relative path, which creates the wrong directory structure.